### PR TITLE
Correction AMD 

### DIFF
--- a/postinstallation.sh
+++ b/postinstallation.sh
@@ -25,7 +25,9 @@ function main() {
         sudo dracut --force
         sudo dnf install akmod-nvidia libva-vdpau-driver libva-utils xorg-x11-drv-nvidia-libs xorg-x11-drv-nvidia-cuda vulkan
     elif [[ "${gpu}" == "amd" ]]; then
-        sudo dnf install xorg-x11-drv-amdgpu
+        sudo dnf install mesa-libOpenCL mesa-libd3d mesa-va-drivers mesa-vdpau-drivers
+ hip hip-devel hsakmt rocm-clinfo rocm-cmake rocm-comgr rocm-device-libs rocm-hip rocm-hip-devel rocm-opencl rocm-opencl-devel rocm-runtime rocm-smi rocminfo
+        
     fi
 
     dnf install -y gstreamer1-plugins-{base,good,bad-free,good-extras,bad-free-extras,ugly-free} gstreamer1-libav

--- a/postinstallation.sh
+++ b/postinstallation.sh
@@ -25,8 +25,7 @@ function main() {
         sudo dracut --force
         sudo dnf install akmod-nvidia libva-vdpau-driver libva-utils xorg-x11-drv-nvidia-libs xorg-x11-drv-nvidia-cuda vulkan
     elif [[ "${gpu}" == "amd" ]]; then
-        sudo dnf install mesa-libOpenCL mesa-libd3d mesa-va-drivers mesa-vdpau-drivers
- hip hip-devel hsakmt rocm-clinfo rocm-cmake rocm-comgr rocm-device-libs rocm-hip rocm-hip-devel rocm-opencl rocm-opencl-devel rocm-runtime rocm-smi rocminfo
+        sudo dnf install mesa-libOpenCL mesa-libd3d mesa-va-drivers mesa-vdpau-drivers hip hip-devel hsakmt rocm-clinfo rocm-cmake rocm-comgr rocm-device-libs rocm-hip rocm-hip-devel rocm-opencl rocm-opencl-devel rocm-runtime rocm-smi rocminfo
         
     fi
 


### PR DESCRIPTION
J'ai viré amd-gpu qui concrètement prend la priorité sur MESA alors que c'est moins bon. et j'ai ajouté rocm pour le montage vidéo et des paquets mesa.

Source rocm : https://www.amd.com/fr/graphics/servers-solutions-rocm ; https://doc.fedora-fr.org/wiki/Carte_graphique_AMD_Radeon_:_installation_des_pilotes_libres#ROCM_5.5.1_et_+_(Fedora_Linux_38_et_+)

Source paquets mesa : https://doc.fedora-fr.org/wiki/Carte_graphique_AMD_Radeon_:_installation_des_pilotes_libres#Avant_tout

À vérifier je ne suis pas un pro Fedora en tout cas amd-gpu c'était pas bon du tout. 